### PR TITLE
Bump up commons-io to fix vuln.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
       <dependency>
          <groupId>commons-io</groupId>
          <artifactId>commons-io</artifactId>
-         <version>2.5/version>
+         <version>2.11.0</version>
       </dependency>
    </dependencies>
    <build>


### PR DESCRIPTION
Bump up commons-io to [2.11.0](https://mvnrepository.com/artifact/commons-io/commons-io/2.11.0)